### PR TITLE
Allow pulling original size or specifying only height or width

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,23 +118,19 @@ function resizeImage (filePath, requestData, data, options, cb) {
                     requestData.width = parseInt(requestData.width)
                 }
 
-
                 if(typeof(requestData.height) !== "undefined" && typeof(requestData.width) === "undefined" ){
                     var aspect = size.width / size.height;
                     requestData.width = aspect * requestData.height;
                 }
 
-
                 if(typeof(requestData.width) !== "undefined" && typeof(requestData.height) === "undefined" ){
                     var aspect = size.height / size.width;
                     requestData.height = aspect * requestData.width;
                 }
+                    // might be a good idea to add a maximum size param? Don't want to store people's 24mp images.
 
-                console.log("requestData is");
-                console.dir(requestData);
-
-                if (options.originalSize){
-                    // do nothing, we're not actually resizing
+                if (requestData.originalSize){
+                    // No need to resize at all
                 } else if (options.scaleUp || (!options.scaleUp && ( size.width > requestData.width || size.height > requestData.height)) ) {
                     this.quality(options.quality);
                     if (requestData.crop) {
@@ -179,7 +175,7 @@ function getImageMetadataAndBuffer (filePath, cb) {
 
 
 function getFilePath (requestData, options) {
-    if(options.originalSize){
+    if(requestData.originalSize){
         var cacheSubDirectory = "originalSize";
     } else {
         var cacheSubDirectory = requestData.width + "-" + requestData.height;

--- a/index.js
+++ b/index.js
@@ -121,7 +121,6 @@ function resizeImage (filePath, requestData, data, options, cb) {
                 var aspect = size.width / size.height;
 
                 if(typeof requestData.height === "number" && typeof requestData.width === "undefined" ){
-                    console.log(typeof requestData.height);
                     requestData.width = aspect * requestData.height;
                 }
 
@@ -185,8 +184,6 @@ function getFilePath (requestData, options) {
     }
 
     cacheSubDirectory += requestData.crop ? "-crop" : "-nocrop";
-    console.dir(requestData);
-    console.log("subdir is " + cacheSubDirectory+"\n\n\n\n");
 
     return options.cacheDirectory + "/" + cacheSubDirectory + "/" + md5(requestData.url);
 }

--- a/index.js
+++ b/index.js
@@ -120,21 +120,17 @@ function resizeImage (filePath, requestData, data, options, cb) {
 
                 var aspect = size.width / size.height;
 
-                if(typeof(requestData.height) !== "undefined" && typeof(requestData.width) === "undefined" ){
-                    // var aspect = size.width / size.height;
+                if(typeof requestData.height === "number" && typeof requestData.width === "undefined" ){
+                    console.log(typeof requestData.height);
                     requestData.width = aspect * requestData.height;
                 }
 
-                if(typeof(requestData.width) !== "undefined" && typeof(requestData.height) === "undefined" ){
-                    // var aspect = size.height / size.width;
+                if(typeof requestData.width === "number" && typeof requestData.height === "undefined" ){
                     requestData.height =  requestData.width / aspect;
                 }
-                    // might be a good idea to add a maximum size param? Don't want to store people's 24mp images.
 
-                if (requestData.originalSize){
-                    console.log("orig");
-                    // No need to resize at all
-                } else if (options.scaleUp || (!options.scaleUp && ( size.width > requestData.width || size.height > requestData.height)) ) {
+                    // might be a good idea to add a maximum size param? Don't want to store people's 24mp images.
+                if(!requestData.originalSize && (options.scaleUp || (!options.scaleUp && ( size.width > requestData.width || size.height > requestData.height))) ) {
                     this.quality(options.quality);
                     if (requestData.crop) {
                         width = requestData.width;
@@ -179,6 +175,9 @@ function getImageMetadataAndBuffer (filePath, cb) {
 
 function getFilePath (requestData, options) {
     var cacheSubDirectory;
+    // If either height or width is undefined, then we get something
+    // like "undefined-300". But then again, maybe that's OK, since we're
+    // not defining that dimension.
     if(requestData.originalSize){
         cacheSubDirectory = "originalSize";
     } else {

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function getRemoteImage (requestData, filePath, options, cb) {
     request.get({
         uri: requestData.url, encoding: null, headers: { "user-agent": userAgent }
     }, function (err, response, data) {
-        if (err) { return cb(new Error("Broken request")); }
+        if (err) { return cb(new Error(err)); }
         // check status codes
         if ([200,301,302].indexOf(response.statusCode) === -1) { return cb(new Error("Broken URL")); }
         // check if in range of valid content types

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var defaultOptions = {
          cacheMaxAge: 1000 * 60 * 60 * 24 * 100*/
     },
     defaultRequestData = {
-        url: null, width: 300, height: 300, crop: false
+        url: null, /*width: 800, height: 800,*/ crop: false
     },
     contentTypes = [ "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"],
     userAgent = "Sickle.js by marksyzm (ignore; Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36)";
@@ -108,7 +108,34 @@ function resizeImage (filePath, requestData, data, options, cb) {
                 var width, height;
                 var size = metadata.size;
 
-                if (options.scaleUp || (!options.scaleUp && ( size.width > requestData.width || size.height > requestData.height))) {
+
+                // This lets us use just a width or height if desired
+                if("height" in requestData){
+                    requestData.height = parseInt(requestData.height)
+                }
+
+                if("width" in requestData){
+                    requestData.width = parseInt(requestData.width)
+                }
+
+
+                if(typeof(requestData.height) !== "undefined" && typeof(requestData.width) === "undefined" ){
+                    var aspect = size.width / size.height;
+                    requestData.width = aspect * requestData.height;
+                }
+
+
+                if(typeof(requestData.width) !== "undefined" && typeof(requestData.height) === "undefined" ){
+                    var aspect = size.height / size.width;
+                    requestData.height = aspect * requestData.width;
+                }
+
+                console.log("requestData is");
+                console.dir(requestData);
+
+                if (options.originalSize){
+                    // do nothing, we're not actually resizing
+                } else if (options.scaleUp || (!options.scaleUp && ( size.width > requestData.width || size.height > requestData.height)) ) {
                     this.quality(options.quality);
                     if (requestData.crop) {
                         width = requestData.width;
@@ -152,7 +179,12 @@ function getImageMetadataAndBuffer (filePath, cb) {
 
 
 function getFilePath (requestData, options) {
-    var cacheSubDirectory = requestData.width + "-" + requestData.height;
+    if(options.originalSize){
+        var cacheSubDirectory = "originalSize";
+    } else {
+        var cacheSubDirectory = requestData.width + "-" + requestData.height;
+    }
+
     cacheSubDirectory += requestData.crop ? "-crop" : "-nocrop";
 
     return options.cacheDirectory + "/" + cacheSubDirectory + "/" + md5(requestData.url);

--- a/index.js
+++ b/index.js
@@ -111,25 +111,28 @@ function resizeImage (filePath, requestData, data, options, cb) {
 
                 // This lets us use just a width or height if desired
                 if("height" in requestData){
-                    requestData.height = parseInt(requestData.height)
+                    requestData.height = parseInt(requestData.height);
                 }
 
                 if("width" in requestData){
-                    requestData.width = parseInt(requestData.width)
+                    requestData.width = parseInt(requestData.width);
                 }
 
+                var aspect = size.width / size.height;
+
                 if(typeof(requestData.height) !== "undefined" && typeof(requestData.width) === "undefined" ){
-                    var aspect = size.width / size.height;
+                    // var aspect = size.width / size.height;
                     requestData.width = aspect * requestData.height;
                 }
 
                 if(typeof(requestData.width) !== "undefined" && typeof(requestData.height) === "undefined" ){
-                    var aspect = size.height / size.width;
-                    requestData.height = aspect * requestData.width;
+                    // var aspect = size.height / size.width;
+                    requestData.height =  requestData.width / aspect;
                 }
                     // might be a good idea to add a maximum size param? Don't want to store people's 24mp images.
 
                 if (requestData.originalSize){
+                    console.log("orig");
                     // No need to resize at all
                 } else if (options.scaleUp || (!options.scaleUp && ( size.width > requestData.width || size.height > requestData.height)) ) {
                     this.quality(options.quality);
@@ -175,13 +178,16 @@ function getImageMetadataAndBuffer (filePath, cb) {
 
 
 function getFilePath (requestData, options) {
+    var cacheSubDirectory;
     if(requestData.originalSize){
-        var cacheSubDirectory = "originalSize";
+        cacheSubDirectory = "originalSize";
     } else {
-        var cacheSubDirectory = requestData.width + "-" + requestData.height;
+        cacheSubDirectory = requestData.width + "-" + requestData.height;
     }
 
     cacheSubDirectory += requestData.crop ? "-crop" : "-nocrop";
+    console.dir(requestData);
+    console.log("subdir is " + cacheSubDirectory+"\n\n\n\n");
 
     return options.cacheDirectory + "/" + cacheSubDirectory + "/" + md5(requestData.url);
 }


### PR DESCRIPTION
This makes it possible to specify an "originalSize" option, for no resizing at all. This is helpful if you're using this as a simple cache.

You can also choose to specify only a height or width, and the aspect ratio will be preserved.
